### PR TITLE
feat: :sparkles: Change Textfield type to number 

### DIFF
--- a/components/utils/IconsPicker.js
+++ b/components/utils/IconsPicker.js
@@ -88,6 +88,7 @@ const IconsPicker = ({ data, setData }) => {
       <p className="text-xs text-[#666] dark:text-[#bbb] my-3">Icon Size</p>
       <TextField
         label="Font Size"
+        type="number"
         variant="outlined"
         size="small"
         value={data.icon.fontSize}

--- a/components/utils/TextTab.js
+++ b/components/utils/TextTab.js
@@ -87,6 +87,7 @@ const TextTab = ({ title, setTitle, name }) => {
       <p className="text-xs text-[#666] dark:text-[#bbb] my-3">Font Size</p>
       <TextField
         label="Font Size"
+        type="number"
         variant="outlined"
         size="small"
         value={title.fontSize}
@@ -96,6 +97,7 @@ const TextTab = ({ title, setTitle, name }) => {
       <p className="text-xs text-[#666] dark:text-[#bbb] my-3">Line Height</p>
       <TextField
         label="Line Height"
+        type="number"
         variant="outlined"
         size="small"
         value={title.lineHeight}


### PR DESCRIPTION
Change input type from **text** to **number** for numeric values.

Allow users to change the font size using keyboard arrow keys

**After** 

![Screenshot from 2021-07-31 18-21-43](https://user-images.githubusercontent.com/17003525/127740892-becdf923-e043-4f53-90a9-0ba67c09a293.png)
